### PR TITLE
Fix handler bootstrap issues

### DIFF
--- a/includes/pml-headless-helpers.php
+++ b/includes/pml-headless-helpers.php
@@ -167,3 +167,37 @@ function pml_headless_set_cache( string $cache_key, $value, int $expiration, wpd
     );
 }
 
+/**
+ * Retrieves upload directory information in a headless context.
+ * This is a lightweight, SHORTINIT-safe replacement for wp_upload_dir().
+ *
+ * @param wpdb $wpdb WordPress database object.
+ * @return array{'basedir': string, 'baseurl': string} Information about the upload directory.
+ */
+function pml_headless_get_upload_dir( wpdb $wpdb ): array
+{
+    $siteurl     = pml_headless_get_option( 'siteurl', '', $wpdb );
+    $upload_path = trim( pml_headless_get_option( 'upload_path', 'wp-content/uploads', $wpdb ) );
+
+    if ( empty( $upload_path ) || 'wp-content/uploads' === $upload_path )
+    {
+        $basedir = WP_CONTENT_DIR . '/uploads';
+        $baseurl = WP_CONTENT_URL . '/uploads';
+    }
+    elseif ( 0 === strpos( $upload_path, ABSPATH ) )
+    {
+        $basedir = $upload_path;
+        $baseurl = str_replace( ABSPATH, $siteurl . '/', $upload_path );
+    }
+    else
+    {
+        $basedir = ABSPATH . $upload_path;
+        $baseurl = $siteurl . '/' . $upload_path;
+    }
+
+    return [
+        'basedir' => $basedir,
+        'baseurl' => $baseurl,
+    ];
+}
+

--- a/pml-constants.php
+++ b/pml-constants.php
@@ -1,0 +1,21 @@
+<?php
+// Shared plugin constants for Protected Media Links.
+
+const PML_PLUGIN_NAME     = 'Protected Media Links';
+const PML_PLUGIN_SLUG     = 'protected-media-links';
+const PML_TEXT_DOMAIN     = 'protected-media-links';
+const PML_PREFIX          = 'pml';
+const PML_VERSION         = '1.1.0';
+const PML_DB_VERSION      = '1.0.0';
+const PML_MIN_WP_VERSION  = '5.8';
+const PML_MIN_PHP_VERSION = '7.4';
+const PML_PLUGIN_FILE     = __DIR__ . '/protected-media-links.php';
+define( 'PML_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'PML_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+const PML_SELECT2_VERSION = '4.0.13';
+
+// Prefix path for Nginx or LiteSpeed internal redirects.
+// Define this in wp-config.php to enable X-Accel-Redirect or X-LiteSpeed-Location.
+if ( ! defined( 'PML_INTERNAL_REDIRECT_PREFIX' ) ) {
+    define( 'PML_INTERNAL_REDIRECT_PREFIX', '' );
+}

--- a/protected-media-links.php
+++ b/protected-media-links.php
@@ -22,25 +22,8 @@ if ( !defined( 'ABSPATH' ) )
     exit;
 }
 
-// Define plugin constants.
-const PML_PLUGIN_NAME      = 'Protected Media Links';
-const PML_PLUGIN_SLUG      = 'protected-media-links';
-const PML_TEXT_DOMAIN      = 'protected-media-links';
-const PML_PREFIX           = 'pml';
-const PML_VERSION          = '1.1.0';
-const PML_DB_VERSION       = '1.0.0';
-const PML_MIN_WP_VERSION   = '5.8';
-const PML_MIN_PHP_VERSION  = '7.4';
-const PML_PLUGIN_FILE      = __FILE__;
-define( 'PML_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-define( 'PML_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-const PML_SELECT2_VERSION  = '4.0.13';
-
-// Prefix path for Nginx or LiteSpeed internal redirects.
-// Define this in wp-config.php to enable X-Accel-Redirect or X-LiteSpeed-Location.
-if ( ! defined( 'PML_INTERNAL_REDIRECT_PREFIX' ) ) {
-    define( 'PML_INTERNAL_REDIRECT_PREFIX', '' );
-}
+// Load shared plugin constants.
+require_once __DIR__ . '/pml-constants.php';
 
 $pml_generated_links_cache = [];
 


### PR DESCRIPTION
## Summary
- share plugin constants across entrypoints
- bootstrap handler with new constant file
- add headless-friendly upload directory helper
- add cache-control headers and logging for downloads
- avoid using unavailable functions in SHORTINIT

## Testing
- `php -l pml-handler.php`
- `php -l protected-media-links.php`
- `php -l includes/pml-headless-helpers.php`
- `php -l pml-constants.php`
- `npm run lint:js` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f3177d8c8320896e7da7a85c3c4c