### PR TITLE
Dynamic htaccess rule generation

### DIFF
--- a/includes/class-install.php
+++ b/includes/class-install.php
@@ -52,7 +52,7 @@ class PML_Install
         self::create_database_table();
         self::run_database_upgrades();
         self::set_default_options();
-        self::manage_htaccess_rules();
+        self::regenerate_htaccess_rules();
 
         $cleanup_enabled = get_option( PML_PREFIX . '_settings_cleanup_tokens_enabled', true ); // Default to true if not set
         if ( $cleanup_enabled )
@@ -81,9 +81,176 @@ class PML_Install
         }
     }
 
+
+    /**
+     * Regenerates the Apache rewrite rules based on protected attachments.
+     * Removes the block entirely when no protected files are found or when
+     * called with $add set to false.
+     *
+     * @param bool $add Whether to add rules or remove them.
+     *
+     * @return bool True on success, false on failure.
+     */
+    public static function regenerate_htaccess_rules( bool $add = true ): bool
+    {
+        if ( ! function_exists( 'get_home_path' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+        }
+
+        $htaccess_file = get_home_path() . '.htaccess';
+        $marker_name   = PML_PLUGIN_NAME;
+
+        if ( ! file_exists( $htaccess_file ) ) {
+            if ( ! is_writable( get_home_path() ) ) {
+                error_log( PML_PLUGIN_NAME . ' Htaccess Error: Cannot create .htaccess, home path not writable.' );
+                return false;
+            }
+            if ( false === @file_put_contents( $htaccess_file, '' ) ) {
+                error_log( PML_PLUGIN_NAME . ' Htaccess Error: Failed to create empty .htaccess file.' );
+                return false;
+            }
+        } elseif ( ! is_writable( $htaccess_file ) ) {
+            error_log( PML_PLUGIN_NAME . ' Htaccess Error: .htaccess file is not writable at ' . $htaccess_file );
+            set_transient( PML_PREFIX . '_admin_notice_htaccess_writable', true, MINUTE_IN_SECONDS * 5 );
+            return false;
+        }
+
+        $htaccess_content = @file_get_contents( $htaccess_file );
+        if ( false === $htaccess_content ) {
+            error_log( PML_PLUGIN_NAME . ' Htaccess Error: Could not read .htaccess file.' );
+            return false;
+        }
+
+        $htaccess_content = str_replace( "\r\n", "\n", $htaccess_content );
+        $htaccess_content = preg_replace( "/# BEGIN Protected Media Links(.*?)# END Protected Media Links\s*/is", '', $htaccess_content );
+        $htaccess_content = trim( $htaccess_content );
+
+        $rules = [];
+        if ( $add ) {
+            $directories = self::get_protected_directories();
+            if ( empty( $directories ) ) {
+                $add = false;
+            } else {
+                foreach ( $directories as $dir => $extensions ) {
+                    $extensions_regex = implode( '|', $extensions );
+                    $dir_path         = '' === $dir ? '' : trailingslashit( $dir );
+
+                    $rules[] = 'RewriteEngine On';
+                    $rules[] = 'RewriteCond %{REQUEST_FILENAME} -f';
+                    $rules[] = 'RewriteCond %{REQUEST_URI} ^/wp-content/uploads/' . $dir_path . '.*\.(' . $extensions_regex . ')$ [NC]';
+                    $rules[] = 'RewriteRule ^wp-content/uploads/' . $dir_path . '(.*)$ wp-content/plugins/' . PML_PLUGIN_SLUG . '/pml-handler.php?pml_media_request=$1 [QSA,L]';
+                    $rules[] = '';
+                }
+            }
+        }
+
+        if ( $add ) {
+            $pml_block     = '# BEGIN ' . $marker_name . "\n" . trim( implode( "\n", $rules ) ) . "\n# END " . $marker_name;
+            $wp_marker     = '# BEGIN WordPress';
+            $wp_marker_pos = strpos( $htaccess_content, $wp_marker );
+
+            if ( false !== $wp_marker_pos ) {
+                $pre_wp_block     = substr( $htaccess_content, 0, $wp_marker_pos );
+                $post_wp_block    = substr( $htaccess_content, $wp_marker_pos );
+                $htaccess_content = trim( $pre_wp_block ) . "\n\n" . $pml_block . "\n\n" . $post_wp_block;
+            } else {
+                $htaccess_content .= "\n\n" . $pml_block;
+            }
+        }
+
+        $htaccess_content = preg_replace( "/\n{3,}/", "\n\n", trim( $htaccess_content ) );
+        if ( false === @file_put_contents( $htaccess_file, $htaccess_content . "\n" ) ) {
+            error_log( PML_PLUGIN_NAME . ' Htaccess Error: Failed to write updated rules to .htaccess file.' );
+            set_transient( PML_PREFIX . '_admin_notice_htaccess_needed', true, MINUTE_IN_SECONDS * 5 );
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns Nginx configuration snippets for protected directories.
+     *
+     * @return array<int, string> Array of Nginx config lines.
+     */
+    public static function get_nginx_config_snippets(): array
+    {
+        $directories = self::get_protected_directories();
+        $snippets    = [];
+
+        foreach ( $directories as $dir => $extensions ) {
+            if ( empty( $extensions ) ) {
+                continue;
+            }
+
+            $extensions_regex = implode( '|', $extensions );
+            $dir_path         = '' === $dir ? '' : trailingslashit( $dir );
+
+            $snippets[] = 'location ~ ^/wp-content/uploads/' . $dir_path . '.*\.(' . $extensions_regex . ')$ {';
+            $snippets[] = '    if (!-f $request_filename) {';
+            $snippets[] = '        return 404;';
+            $snippets[] = '    }';
+            $snippets[] = '    rewrite ^/wp-content/uploads/' . $dir_path . '(.*)$ /wp-content/plugins/' . PML_PLUGIN_SLUG . '/pml-handler.php?pml_media_request=$1 last;';
+            $snippets[] = '}';
+            $snippets[] = '';
+        }
+
+        return $snippets;
+    }
+
+    /**
+     * Collects directories and extensions for all protected attachments.
+     *
+     * @return array<string, array<int, string>> Map of directory paths to extensions.
+     */
+    private static function get_protected_directories(): array
+    {
+        $query_args = [
+            'post_type'      => 'attachment',
+            'post_status'    => 'inherit',
+            'posts_per_page' => -1,
+            'fields'         => 'ids',
+            'meta_query'     => [
+                [
+                    'key'   => '_' . PML_PREFIX . '_is_protected',
+                    'value' => '1',
+                ],
+            ],
+        ];
+
+        $attachment_ids = get_posts( $query_args );
+        $directories    = [];
+
+        foreach ( $attachment_ids as $attachment_id ) {
+            $relative_path = get_post_meta( $attachment_id, '_wp_attached_file', true );
+            if ( ! $relative_path ) {
+                continue;
+            }
+
+            $dir = dirname( $relative_path );
+            if ( '.' === $dir ) {
+                $dir = '';
+            }
+            $ext = strtolower( pathinfo( $relative_path, PATHINFO_EXTENSION ) );
+
+            if ( ! isset( $directories[ $dir ] ) ) {
+                $directories[ $dir ] = [];
+            }
+
+            if ( $ext ) {
+                $directories[ $dir ][] = $ext;
+            }
+        }
+
+        foreach ( $directories as $dir => $exts ) {
+            $directories[ $dir ] = array_unique( $exts );
+        }
+
+        return $directories;
+    }
     public static function deactivate()
     {
-        self::manage_htaccess_rules( false );
+        self::regenerate_htaccess_rules( false );
         wp_clear_scheduled_hook( PML_PREFIX . '_daily_token_cleanup_hook' );
         flush_rewrite_rules();
     }
@@ -194,150 +361,6 @@ class PML_Install
         }
     }
 
-    /**
-     * Manages .htaccess rules for the plugin, inserting them before the WordPress block.
-     *
-     * @param bool $add True to add rules, false to remove.
-     *
-     * @return bool True on success, false on failure or if not applicable.
-     */
-    public static function manage_htaccess_rules( bool $add = true ): bool
-    {
-        // This function requires file system access
-        if ( !function_exists( 'get_home_path' ) )
-        {
-            require_once ABSPATH . 'wp-admin/includes/file.php';
-        }
-
-        $htaccess_file = get_home_path() . '.htaccess';
-        $marker_name   = PML_PLUGIN_NAME;
-
-        // Check for .htaccess file existence and writability
-        if ( !file_exists( $htaccess_file ) )
-        {
-            if ( !is_writable( get_home_path() ) )
-            {
-                error_log( PML_PLUGIN_NAME . ' Htaccess Error: Cannot create .htaccess, home path not writable.' );
-                return false;
-            }
-            if ( false === @file_put_contents( $htaccess_file, '' ) )
-            {
-                error_log( PML_PLUGIN_NAME . ' Htaccess Error: Failed to create empty .htaccess file.' );
-                return false;
-            }
-        }
-        elseif ( !is_writable( $htaccess_file ) )
-        {
-            error_log( PML_PLUGIN_NAME . ' Htaccess Error: .htaccess file is not writable at ' . $htaccess_file );
-            set_transient( PML_PREFIX . '_admin_notice_htaccess_writable', true, MINUTE_IN_SECONDS * 5 );
-            return false;
-        }
-
-        // Read the current .htaccess content
-        $htaccess_content = @file_get_contents( $htaccess_file );
-        if ( false === $htaccess_content )
-        {
-            error_log( PML_PLUGIN_NAME . ' Htaccess Error: Could not read .htaccess file.' );
-            return false;
-        }
-
-        // Sanitize EOL characters for consistency and remove any existing PML block
-        $htaccess_content = str_replace( "\r\n", "\n", $htaccess_content );
-        $htaccess_content = preg_replace( "/# BEGIN Protected Media Links(.*?)# END Protected Media Links\s*/is", '', $htaccess_content );
-        $htaccess_content = trim( $htaccess_content );
-
-        if ( $add )
-        {
-            // Define the specific file extensions to protect
-            $protectable_extensions = [
-                // document and media file extensions
-                'pdf',
-                'doc',
-                'docx',
-                'ppt',
-                'pptx',
-                'pps',
-                'ppsx',
-                'odt',
-                'xls',
-                'xlsx',
-                'csv',
-                'txt',
-                'rtf',
-                // archive and image file extensions
-                'zip',
-                'rar',
-                '7z',
-                'tar',
-                'gz',
-                // image and audio/video file extensions
-                'jpg',
-                'jpeg',
-                'jpe',
-                'png',
-                'gif',
-                'webp',
-                'bmp',
-                'tif',
-                'tiff',
-                'svg',
-                // audio and video file extensions
-                'mp3',
-                'wav',
-                'ogg',
-                'm4a',
-                // video file extensions
-                'mp4',
-                'mov',
-                'wmv',
-                'avi',
-                'mpg',
-                'mpeg',
-                'm4v',
-                'webm',
-            ];
-            $extensions_regex       = implode( '|', $protectable_extensions );
-
-            $rules = [
-                'RewriteEngine On',
-                'RewriteCond %{REQUEST_FILENAME} -f',
-                'RewriteCond %{REQUEST_URI} \.(' . $extensions_regex . ')$ [NC]',
-                'RewriteRule ^wp-content/uploads/(.*)$ wp-content/plugins/' . PML_PLUGIN_SLUG . '/pml-handler.php?pml_media_request=$1 [QSA,L]',
-            ];
-
-            // Build the new block content with markers
-            $pml_block = '# BEGIN ' . $marker_name . "\n";
-            $pml_block .= implode( "\n", $rules ) . "\n";
-            $pml_block .= '# END ' . $marker_name;
-
-            $wp_marker     = '# BEGIN WordPress';
-            $wp_marker_pos = strpos( $htaccess_content, $wp_marker );
-
-            if ( false !== $wp_marker_pos )
-            {
-                // Insert the PML block right before the WordPress block
-                $pre_wp_block     = substr( $htaccess_content, 0, $wp_marker_pos );
-                $post_wp_block    = substr( $htaccess_content, $wp_marker_pos );
-                $htaccess_content = trim( $pre_wp_block ) . "\n\n" . $pml_block . "\n\n" . $post_wp_block;
-            }
-            else
-            {
-                // Fallback: WordPress block not found, append PML block at the end
-                $htaccess_content .= "\n\n" . $pml_block;
-            }
-        }
-
-        // Clean up extra newlines and write the updated content back to the file
-        $htaccess_content = preg_replace( "/\n{3,}/", "\n\n", trim( $htaccess_content ) );
-        if ( false === @file_put_contents( $htaccess_file, $htaccess_content . "\n" ) )
-        {
-            error_log( PML_PLUGIN_NAME . ' Htaccess Error: Failed to write updated rules to .htaccess file.' );
-            set_transient( PML_PREFIX . '_admin_notice_htaccess_needed', true, MINUTE_IN_SECONDS * 5 );
-            return false;
-        }
-
-        return true;
-    }
 
     public static function are_htaccess_rules_present(): bool
     {


### PR DESCRIPTION
## Summary
- rename `manage_htaccess_rules` to `regenerate_htaccess_rules`
- rebuild `.htaccess` rules from protected attachments
- expose parallel Nginx configuration helper

## Testing
- `npm run lint:js` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684608d79a308320bbd52dde20855276