### PR TITLE
Update htaccess on protection status change

### DIFF
--- a/includes/class-install.php
+++ b/includes/class-install.php
@@ -357,6 +357,15 @@ class PML_Install
     }
 
     /**
+     * Removes and re-adds the plugin's htaccess rules.
+     */
+    public static function regenerate_htaccess_rules(): bool
+    {
+        self::manage_htaccess_rules( false );
+        return self::manage_htaccess_rules();
+    }
+
+    /**
      * Runs database upgrade routines.
      * This should be hooked to 'plugins_loaded' or similar early action.
      */

--- a/includes/class-media-library-integration.php
+++ b/includes/class-media-library-integration.php
@@ -341,6 +341,10 @@ class PML_Media_Library_Integration
                     $processed_count,
                 ) : sprintf( _n( '%d item unprotected.', '%d items unprotected.', $processed_count, PML_TEXT_DOMAIN ), $processed_count );
                 $redirect_to = add_query_arg( PML_PREFIX . '_bulk_message', rawurlencode( $message ), $redirect_to );
+                if ( method_exists( 'PML_Install', 'regenerate_htaccess_rules' ) )
+                {
+                    PML_Install::regenerate_htaccess_rules();
+                }
             }
         }
         return $redirect_to;
@@ -488,8 +492,14 @@ class PML_Media_Library_Integration
         }
 
         $new_status_value = ( 'protect' === $new_action ) ? '1' : '0';
+        $old_value       = get_post_meta( $attachment_id, '_' . PML_PREFIX . '_is_protected', true );
         update_post_meta( $attachment_id, '_' . PML_PREFIX . '_is_protected', $new_status_value );
+        $status_changed   = (string)$old_value !== $new_status_value;
         $is_protected_bool = ( '1' === $new_status_value );
+        if ( $status_changed && method_exists( 'PML_Install', 'regenerate_htaccess_rules' ) )
+        {
+            PML_Install::regenerate_htaccess_rules();
+        }
 
         wp_send_json_success(
             [

--- a/includes/class-media-meta.php
+++ b/includes/class-media-meta.php
@@ -446,6 +446,10 @@ class PML_Media_Meta
         // These fields are submitted directly with PML_PREFIX names.
         $is_protected_value = isset( $_POST[ PML_PREFIX . '_is_protected' ] ) ? '1' : '0';
         update_post_meta( $post_id, '_' . PML_PREFIX . '_is_protected', $is_protected_value );
+        if ( method_exists( 'PML_Install', 'regenerate_htaccess_rules' ) )
+        {
+            PML_Install::regenerate_htaccess_rules();
+        }
 
         $redirect_url_value = isset( $_POST[ PML_PREFIX . '_redirect_url' ] ) ? esc_url_raw( wp_unslash( $_POST[ PML_PREFIX . '_redirect_url' ] ) )
             : '';


### PR DESCRIPTION
## Summary
- regenerate htaccess rules whenever protection status changes
- add wrapper method for regenerating htaccess rules

## Testing
- `npm run lint:js` *(fails: wp-scripts not found)*
- `php -l includes/class-media-meta.php`
- `php -l includes/class-media-library-integration.php`
- `php -l includes/class-install.php`


------
https://chatgpt.com/codex/tasks/task_e_684608dbf31c8320ba57672819273a73