### PR TITLE
Fix rule regeneration methods

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1051,7 +1051,7 @@ class PML_Settings
                 ) . '</p>';
             echo '<pre class="pml-code-block"><code>';
             if ( class_exists( 'PML_Install' ) ) {
-                echo esc_html( PML_Install::regenerate_htaccess_rules() );
+                echo esc_html( PML_Install::get_htaccess_rules_snippet() );
             }
             echo '</code></pre>';
             if ( class_exists( 'PML_Install' ) && !PML_Install::are_htaccess_rules_present() )


### PR DESCRIPTION
## Summary
- refactor duplication in `PML_Install`
- add helper for Apache rules snippets
- add method to output nginx configuration
- show snippet using new helpers in settings page

## Testing
- `php -l includes/class-install.php`
- `php -l includes/class-settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68460f0e94b883209ccbde6be5604f83