### PR TITLE
Fix rewrite rule generation

### DIFF
--- a/includes/class-install.php
+++ b/includes/class-install.php
@@ -133,11 +133,11 @@ class PML_Install
             if ( empty( $directories ) ) {
                 $add = false;
             } else {
+                $rules[] = 'RewriteEngine On';
                 foreach ( $directories as $dir => $extensions ) {
                     $extensions_regex = implode( '|', $extensions );
                     $dir_path         = '' === $dir ? '' : trailingslashit( $dir );
 
-                    $rules[] = 'RewriteEngine On';
                     $rules[] = 'RewriteCond %{REQUEST_FILENAME} -f';
                     $rules[] = 'RewriteCond %{REQUEST_URI} ^/wp-content/uploads/' . $dir_path . '.*\.(' . $extensions_regex . ')$ [NC]';
                     $rules[] = 'RewriteRule ^wp-content/uploads/' . $dir_path . '(.*)$ wp-content/plugins/' . PML_PLUGIN_SLUG . '/pml-handler.php?pml_media_request=$1 [QSA,L]';


### PR DESCRIPTION
## Summary
- ensure `RewriteEngine On` is added only once in `.htaccess`

## Testing
- `npm run lint:js` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684613052fd08320b8c2f06c44e17872