### PR TITLE
Update plugin activation to set cookie constants

### DIFF
--- a/includes/class-install.php
+++ b/includes/class-install.php
@@ -611,6 +611,11 @@ class PML_Install
             $contents = substr( $contents, 0, $pos ) . $snippet . substr( $contents, $pos );
         }
 
+        if ( ! is_writable( $wp_config ) )
+        {
+            error_log( PML_PLUGIN_NAME . ' Activation Error: wp-config.php is not writable. Please check file permissions.' );
+            return;
+        }
         if ( false === @file_put_contents( $wp_config, $contents ) )
         {
             error_log( PML_PLUGIN_NAME . ' Activation Error: Failed to write cookie constants to wp-config.php.' );


### PR DESCRIPTION
## Summary
- ensure cookie-related constants exist in `wp-config.php`
- add cookie constant check to activation flow

## Testing
- `php -l includes/class-install.php`
- `php -l protected-media-links.php`
- `npm run lint:js` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846589331d08320a60954a0fd5e1a41