### PR TITLE
Add sanitization test

### DIFF
--- a/includes/pml-headless-sanitization.php
+++ b/includes/pml-headless-sanitization.php
@@ -1,0 +1,16 @@
+<?php
+// Common sanitization helpers for Protected Media Links.
+
+if ( ! function_exists( 'pml_headless_sanitize_location' ) ) {
+    /**
+     * Sanitize redirect URLs for header usage.
+     *
+     * @param string $url URL to sanitize.
+     * @return string Sanitized URL without CR or LF characters.
+     */
+    function pml_headless_sanitize_location( string $url ): string {
+        $url = filter_var( $url, FILTER_SANITIZE_URL );
+        return str_replace( [ "\r", "\n" ], '', $url );
+    }
+}
+

--- a/pml-handler.php
+++ b/pml-handler.php
@@ -39,6 +39,8 @@ if ( ! function_exists( 'sanitize_text_field' ) ) {
     }
 }
 
+require_once __DIR__ . "/includes/pml-headless-sanitization.php";
+
 // Load plugin helpers.
 require_once __DIR__ . '/includes/pml-headless-helpers.php';
 require_once __DIR__ . '/includes/class-pml-headless-auth.php';
@@ -162,7 +164,7 @@ function deny_access( ?array $pml_meta, string $slug ): void {
     if ( $pml_meta && ! empty( $pml_meta['pml_redirect_url'] ) ) {
         $default_url = $pml_meta['pml_redirect_url'];
     }
-    $redirect = $default_url ? $default_url : '/';
+    $redirect = $default_url ? pml_headless_sanitize_location( $default_url ) : '/';
     if ( ! headers_sent() ) {
         header( 'Location: ' . $redirect );
     }

--- a/tests/sanitize_location_test.php
+++ b/tests/sanitize_location_test.php
@@ -1,0 +1,19 @@
+<?php
+require_once dirname(__DIR__) . '/includes/pml-headless-sanitization.php';
+
+$input = "https://example.com/path\r\nLocation: https://evil.com";
+$expected = "https://example.com/pathLocation:https://evil.com";
+$result = pml_headless_sanitize_location($input);
+
+if ($result !== $expected) {
+    echo "Sanitization failed: $result\n";
+    exit(1);
+}
+
+if (strpos($result, "\r") !== false || strpos($result, "\n") !== false) {
+    echo "Header injection not removed\n";
+    exit(1);
+}
+
+echo "Sanitization test passed\n";
+


### PR DESCRIPTION
## Summary
- add test to validate CR/LF are stripped from redirect URLs
- move sanitizer into new reusable file
- use production sanitizer in tests

## Testing
- `php -l pml-handler.php`
- `php -l includes/pml-headless-sanitization.php`
- `php -l tests/sanitize_location_test.php`
- `php tests/sanitize_location_test.php`


------
https://chatgpt.com/codex/tasks/task_e_6846dfd974a88320957416c02d00691a