### PR TITLE
refactor: simplify select2 and flatpickr asset enqueuing

### DIFF
--- a/includes/class-media-library-integration.php
+++ b/includes/class-media-library-integration.php
@@ -106,19 +106,8 @@ class PML_Media_Library_Integration
         // Select2 for full attachment edit page (used by media-library.js for meta box)
         if ( $is_attachment_edit_page )
         {
-            wp_enqueue_style(
-                'select2',
-                "https://cdnjs.cloudflare.com/ajax/libs/select2/" . PML_SELECT2_VERSION . "/css/select2.min.css",
-                [],
-                PML_SELECT2_VERSION,
-            );
-            wp_enqueue_script(
-                'select2',
-                "https://cdnjs.cloudflare.com/ajax/libs/select2/" . PML_SELECT2_VERSION . "/js/select2.min.js",
-                [ 'jquery' ],
-                PML_SELECT2_VERSION,
-                true,
-            );
+            wp_enqueue_style( 'select2' );
+            wp_enqueue_script( 'select2' );
             wp_localize_script(
                 PML_PLUGIN_SLUG . '-media-library-js',
                 'pml_admin_params',

--- a/includes/class-media-meta.php
+++ b/includes/class-media-meta.php
@@ -40,19 +40,8 @@ class PML_Media_Meta
             return;
         }
 
-        wp_enqueue_style(
-            'select2',
-            "https://cdnjs.cloudflare.com/ajax/libs/select2/" . PML_SELECT2_VERSION . "/css/select2.min.css",
-            [],
-            PML_SELECT2_VERSION,
-        );
-        wp_enqueue_script(
-            'select2',
-            "https://cdnjs.cloudflare.com/ajax/libs/select2/" . PML_SELECT2_VERSION . "/js/select2.min.js",
-            [ 'jquery' ],
-            PML_SELECT2_VERSION,
-            true,
-        );
+        wp_enqueue_style( 'select2' );
+        wp_enqueue_script( 'select2' );
 
         wp_enqueue_style( PML_PLUGIN_SLUG . '-admin-common-css', PML_PLUGIN_URL . 'admin/assets/css/common.css', [ 'dashicons' ], PML_VERSION );
         wp_enqueue_style(

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -40,19 +40,8 @@ class PML_Settings
         }
 
         // --- Common Assets for All PML Pages ---
-        wp_enqueue_style(
-            'select2',
-            "https://cdnjs.cloudflare.com/ajax/libs/select2/" . PML_SELECT2_VERSION . "/css/select2.min.css",
-            [],
-            PML_SELECT2_VERSION,
-        );
-        wp_enqueue_script(
-            'select2',
-            "https://cdnjs.cloudflare.com/ajax/libs/select2/" . PML_SELECT2_VERSION . "/js/select2.min.js",
-            [ 'jquery' ],
-            PML_SELECT2_VERSION,
-            true,
-        );
+        wp_enqueue_style( 'select2' );
+        wp_enqueue_script( 'select2' );
         wp_enqueue_style( PML_PLUGIN_SLUG . '-admin-common-css', PML_PLUGIN_URL . 'admin/assets/css/common.css', [ 'dashicons' ], PML_VERSION );
         wp_enqueue_script(
             PML_PLUGIN_SLUG . '-admin-common-utils-js',

--- a/includes/class-token-meta-box.php
+++ b/includes/class-token-meta-box.php
@@ -78,10 +78,10 @@ class PML_Token_Meta_Box
 
         wp_enqueue_style( PML_PLUGIN_SLUG . '-admin-common-css', PML_PLUGIN_URL . 'admin/assets/css/common.css', [ 'dashicons' ], PML_VERSION );
         wp_enqueue_style( PML_PLUGIN_SLUG . '-token-meta-box-css', PML_PLUGIN_URL . 'admin/assets/css/token-meta-box.css', [ PML_PLUGIN_SLUG . '-admin-common-css' ], PML_VERSION );
-        wp_enqueue_style( 'flatpickr', 'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css', [], '4.6.13' );
-        wp_enqueue_style( 'select2', "https://cdnjs.cloudflare.com/ajax/libs/select2/" . PML_SELECT2_VERSION . "/css/select2.min.css", [], PML_SELECT2_VERSION );
-        wp_enqueue_script( 'flatpickr', 'https://cdn.jsdelivr.net/npm/flatpickr', [], '4.6.13', true );
-        wp_enqueue_script( 'select2', "https://cdnjs.cloudflare.com/ajax/libs/select2/" . PML_SELECT2_VERSION . "/js/select2.min.js", [ 'jquery' ], PML_SELECT2_VERSION, true );
+        wp_enqueue_style( 'flatpickr' );
+        wp_enqueue_style( 'select2' );
+        wp_enqueue_script( 'flatpickr' );
+        wp_enqueue_script( 'select2' );
         wp_enqueue_script( PML_PLUGIN_SLUG . '-admin-common-utils-js', PML_PLUGIN_URL . 'admin/assets/js/common-utils.js', [ 'jquery', 'wp-i18n' ], PML_VERSION, true );
         wp_set_script_translations( PML_PLUGIN_SLUG . '-admin-common-utils-js', PML_TEXT_DOMAIN, PML_PLUGIN_DIR . 'languages' );
         wp_enqueue_script( PML_PLUGIN_SLUG . '-token-meta-box-js', PML_PLUGIN_URL . 'admin/assets/js/token-meta-box.js', [ 'jquery', 'wp-util', 'wp-i18n', 'flatpickr', 'select2', PML_PLUGIN_SLUG . '-admin-common-utils-js' ], PML_VERSION, true );

--- a/pml-constants.php
+++ b/pml-constants.php
@@ -12,7 +12,6 @@ const PML_MIN_PHP_VERSION = '7.4';
 const PML_PLUGIN_FILE     = __DIR__ . '/protected-media-links.php';
 //define( 'PML_PLUGIN_DIR', pml_plugin_dir_path() ); // defined at the end of this file
 //define( 'PML_PLUGIN_URL', pml_plugin_dir_url() );  // defined at the end of this file
-const PML_SELECT2_VERSION = '4.0.13';
 
 // Prefix path for Nginx or LiteSpeed internal redirects.
 // Define this in wp-config.php to enable X-Accel-Redirect or X-LiteSpeed-Location.


### PR DESCRIPTION
Replaced hardcoded CDN URLs for Select2 and Flatpickr scripts and styles with default WordPress-registered handles. This reduces the reliance on external URLs and aligns with WordPress best practices for asset management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the way Select2 and flatpickr library assets are loaded in the admin interface to use WordPress’s registered handles instead of explicit CDN URLs and versions.
  * Removed the unused Select2 version constant from the configuration.
  * No visible changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->