### PR TITLE
refactor: improve i18n comments and use `wp_is_writable`

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -144,14 +144,17 @@ final class PML_Core
         $parts = [];
         if ( $days > 0 )
         {
+            /* translators: %d: Number of days */
             $parts[] = sprintf( _n( '%d day', '%d days', $days, PML_TEXT_DOMAIN ), $days );
         }
         if ( $hours > 0 )
         {
+            /* translators: %d: Number of hours */
             $parts[] = sprintf( _n( '%d hour', '%d hours', $hours, PML_TEXT_DOMAIN ), $hours );
         }
         if ( $minutes > 0 )
         {
+            /* translators: %d: Number of minutes */
             $parts[] = sprintf( _n( '%d minute', '%d minutes', $minutes, PML_TEXT_DOMAIN ), $minutes );
         }
 

--- a/includes/class-install.php
+++ b/includes/class-install.php
@@ -41,7 +41,7 @@ class PML_Install
                             "<div class=\"notice notice-error\"><p>%s</p></div>",
                             esc_html__(
                                 'Access Lens: Token Manager initialization failed. Please check the plugin files.',
-                                'protected-media-links',
+                                PML_TEXT_DOMAIN,
                             ),
                         );
                     },
@@ -106,7 +106,7 @@ class PML_Install
         $marker_name   = PML_PLUGIN_NAME;
 
         if ( ! file_exists( $htaccess_file ) ) {
-            if ( ! is_writable( get_home_path() ) ) {
+            if ( ! wp_is_writable( get_home_path() ) ) {
                 error_log( PML_PLUGIN_NAME . ' Htaccess Error: Cannot create .htaccess, home path not writable.' );
                 return false;
             }
@@ -114,7 +114,7 @@ class PML_Install
                 error_log( PML_PLUGIN_NAME . ' Htaccess Error: Failed to create empty .htaccess file.' );
                 return false;
             }
-        } elseif ( ! is_writable( $htaccess_file ) ) {
+        } elseif ( ! wp_is_writable( $htaccess_file ) ) {
             error_log( PML_PLUGIN_NAME . ' Htaccess Error: .htaccess file is not writable at ' . $htaccess_file );
             set_transient( PML_PREFIX . '_admin_notice_htaccess_writable', true, MINUTE_IN_SECONDS * 5 );
             return false;
@@ -631,7 +631,7 @@ class PML_Install
             $contents = substr( $contents, 0, $pos ) . $snippet . substr( $contents, $pos );
         }
 
-        if ( ! is_writable( $wp_config ) )
+        if ( ! wp_is_writable( $wp_config ) )
         {
             error_log( PML_PLUGIN_NAME . ' Activation Error: wp-config.php is not writable. Please check file permissions.' );
             return;

--- a/protected-media-links.php
+++ b/protected-media-links.php
@@ -188,6 +188,7 @@ function pml_init_plugin()
                 'admin_notices',
                 function () {
                     echo '<div class="notice notice-error"><p>' . sprintf(
+                            /* translators: %1$s: Plugin name */
                             esc_html__(
                                 '%1$s core class (PML_Core) is missing or could not be autoloaded. The plugin cannot function correctly. Please ensure the class map is up to date or reinstall the plugin.',
                                 PML_TEXT_DOMAIN,
@@ -344,7 +345,8 @@ else
             'admin_notices',
             function () {
                 echo '<div class="notice notice-error"><p>' . sprintf(
-                        esc_html__(
+                    /* translators: %1$s: Plugin name */
+                   esc_html__(
                             '%1$s installation/uninstallation controller class (PML_Install) is missing or could not be autoloaded. The plugin might not (de)activate or uninstall correctly. Please ensure the class map is up to date or reinstall the plugin.',
                             PML_TEXT_DOMAIN,
                         ),


### PR DESCRIPTION
Added translator comments to clarify contexts for translatable strings. Replaced `is_writable` with `wp_is_writable` for better WordPress compatibility and adherence to the WordPress coding standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file permission checks for configuration files to enhance compatibility with WordPress environments.
  * Updated localization handling for admin notices to ensure consistent translation domain usage.

* **Documentation**
  * Added translator comments to clarify placeholders in admin notices and duration formatting, improving translation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->