### PR TITLE
refactor: remove deprecated constants and clean up markup

### DIFF
--- a/includes/class-token-meta-box.php
+++ b/includes/class-token-meta-box.php
@@ -126,7 +126,7 @@ class PML_Token_Meta_Box
         $is_protected  = (bool) get_post_meta( $attachment_id, '_' . PML_PREFIX . '_is_protected', true );
         $prefix        = PML_PREFIX;
 
-        echo "<div id='{$prefix}-token-manager-app' class='pml-token-manager-app' data-attachment-id='{$attachment_id}'>";
+        echo "<div id='$prefix-token-manager-app' class='pml-token-manager-app' data-attachment-id='$attachment_id'>";
 
         if ( !$is_protected )
         {
@@ -142,20 +142,18 @@ class PML_Token_Meta_Box
         $exist_title  = esc_html__( 'Existing Tokens', 'access-lens-protected-media-links' );
         $loading_text = esc_html__( 'Loading tokens...', 'access-lens-protected-media-links' );
 
-        echo <<<EOT
-            <h3>$gen_title</h3>
-            <div class='$prefix-generate-token-form-wrapper'>
+        echo "<h3>$gen_title</h3>
+              <div class='$prefix-generate-token-form-wrapper'>
                 <div id='$prefix-generate-token-form-fields'></div>
                 <button type='button' id='$prefix-generate-token-button' class='button button-primary'>$create_btn</button>
                 <span class='spinner' id='$prefix-generate-token-spinner'></span>
                 <div id='$prefix-generate-token-feedback'></div>
-            </div>
-            <hr>
-            <h3>$exist_title</h3>
-            <div id='$prefix-tokens-list-wrapper'><p class='pml-loading-text'>$loading_text</p></div>
-            <div id='$prefix-token-actions-feedback' style='margin-top: 10px;'></div>
-        EOT;
-        echo "</div>";
+              </div>
+              <hr>
+              <h3>$exist_title</h3>
+              <div id='$prefix-tokens-list-wrapper'><p class='pml-loading-text'>$loading_text</p></div>
+              <div id='$prefix-token-actions-feedback' style='margin-top: 10px;'></div>";
+        echo "</div>"; // closes div#{PML_PREFIX}-token-manager-app
     }
 
     public function ajax_fetch_attachment_tokens(): void

--- a/includes/pml-headless-helpers.php
+++ b/includes/pml-headless-helpers.php
@@ -283,17 +283,6 @@ function pml_headless_define_constants( wpdb $wpdb )
             define( 'WPMU_PLUGIN_URL', rtrim( WP_CONTENT_URL, '/' ) . '/mu-plugins' );
         }
     }
-
-    // Define deprecated relative path constants.
-    // These are string literals, by convention relative to ABSPATH.
-    if ( !defined( 'PLUGINDIR' ) )
-    {
-        define( 'PLUGINDIR', 'wp-content/plugins' );
-    }
-    if ( !defined( 'MUPLUGINDIR' ) )
-    {
-        define( 'MUPLUGINDIR', 'wp-content/mu-plugins' );
-    }
 }
 
 if ( !function_exists( '__' ) )

--- a/pml-constants.php
+++ b/pml-constants.php
@@ -5,7 +5,6 @@ const PML_PLUGIN_NAME     = 'Access Lens';
 const PML_PLUGIN_SLUG     = 'protected-media-links';
 const PML_PREFIX          = 'pml';
 const PML_VERSION         = '1.1.0';
-const PML_DB_VERSION      = '1.0.0';
 const PML_MIN_WP_VERSION  = '5.9';
 const PML_MIN_PHP_VERSION = '7.4';
 const PML_PLUGIN_FILE     = __DIR__ . '/protected-media-links.php';


### PR DESCRIPTION
Eliminated unused constants `PML_DB_VERSION`, `PLUGINDIR`, and `MUPLUGINDIR` as they were no longer required. Simplified and reformatted HTML output in `class-token-meta-box.php` for better readability and maintainability.