### PR TITLE
feat: add CLI execution restriction to class map generator

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,2 @@
+# Files and directories excluded from plugin distribution archives.
+build/

--- a/README.md
+++ b/README.md
@@ -164,3 +164,8 @@ We welcome contributions from the community! Whether it's reporting a bug, sugge
 -   **Security First:** Use nonces, capability checks, and proper sanitization/escaping on all data.
 
 Please open an issue or pull request on our [GitHub repository](https://github.com/TWP-Technologies/Access-Lens).
+
+## 🛠️ Developer Notes
+
+-   **Class map generator:** Run `php build/generate-class-map.php` from the command line whenever classes are added or files are renamed under `includes/`. The script must be executed via the CLI (it will exit early otherwise) and respects the optional `PML_PLUGIN_DIR_FOR_BUILD` constant if the plugin lives outside the default directory layout. A successful run regenerates `includes/pml-class-map.php` with paths relative to the includes directory.
+-   **Release packaging:** WordPress distribution archives created with tools such as `wp dist-archive` automatically exclude the `build/` directory via `.distignore`, ensuring development-only assets are left out of release zips.

--- a/build/generate-class-map.php
+++ b/build/generate-class-map.php
@@ -13,6 +13,12 @@
  * @package AccessLensBuild
  */
 
+if ( 'cli' !== PHP_SAPI )
+{
+    fwrite( STDERR, "This script can only be executed from the command line.\n" );
+    exit( 1 );
+}
+
 echo "Starting Access Lens (PML) class map generation (PHP 7.4 Compatible)...\n";
 
 // Define the plugin directory. Adjust if this script is placed elsewhere.

--- a/pml-constants.php
+++ b/pml-constants.php
@@ -1,4 +1,8 @@
 <?php
+if ( !defined( 'ABSPATH' ) && !defined( 'PML_ALLOW_DIRECT' ) )
+{
+    exit;
+}
 // Shared plugin constants for Access Lens.
 
 const PML_PLUGIN_NAME     = 'Access Lens';

--- a/pml-handler.php
+++ b/pml-handler.php
@@ -3,6 +3,9 @@
 // Bypasses full WordPress load for faster protected file serving.
 
 // --- Phase 1: Minimal Bootstrap ---
+if ( ! defined( 'PML_ALLOW_DIRECT' ) ) {
+    define( 'PML_ALLOW_DIRECT', true );
+}
 require_once dirname( __FILE__ ) . '/pml-constants.php';
 define( 'SHORTINIT', true );
 


### PR DESCRIPTION
feat: add CLI execution restriction to class map generator

Restricted the execution of `generate-class-map.php` to the command line interface (CLI). Added a safeguard that prevents usage in non-CLI environments, ensuring proper script usage and avoiding unintended errors.

feat: add direct access safeguards to core files

Added `PML_ALLOW_DIRECT` constant to permit direct file loading when explicitly defined. Implemented a verification to block unauthorized access to `pml-constants.php` if neither `ABSPATH` nor `PML_ALLOW_DIRECT` is defined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Hardened access controls to block direct web access to internal PHP files.
  * Ensured build scripts run only from the command line.

* Documentation
  * Added Developer Notes covering the class map generator and release packaging behavior.

* Chores
  * Excluded the build directory from distribution archives to streamline package size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->